### PR TITLE
Change primitive types to pointer type for remote support API

### DIFF
--- a/client/model_2_8_support_body.go
+++ b/client/model_2_8_support_body.go
@@ -10,9 +10,9 @@ package pureclient
 
 type Model28SupportBody struct {
 	// The status of phonehome. If set to `true`, enable phonehome. If set to `false`, disable phonehome.
-	PhonehomeEnabled bool `json:"phonehome_enabled,omitempty"`
+	PhonehomeEnabled *bool `json:"phonehome_enabled,omitempty"`
 	// The value of the current proxy, which is used for connecting to cloud services such as phonehome, remote assist, etc. Specify the server name, including the scheme and proxy port number.
-	Proxy string `json:"proxy,omitempty"`
+	Proxy *string `json:"proxy,omitempty"`
 	// The status of a remote assist session. If set to `true`, enable the remote assist session. If set to `false`, disable the remote assist session.
-	RemoteAssistActive bool `json:"remote_assist_active,omitempty"`
+	RemoteAssistActive *bool `json:"remote_assist_active,omitempty"`
 }


### PR DESCRIPTION
1. Json encoding removes any variables with "false" or "0" as values in them assuming they are default. We do not want it. We wanted to send 'false' to Pure

2. Needed to differentiate between empty string from nil string setting proxy to empty string clears it. The pointer helps not clearing an existent proxy configured on the Pure array