### PR TITLE
Adds missing 'key' property of certificate object

### DIFF
--- a/client/docs/Certificate.md
+++ b/client/docs/Certificate.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **IntermediateCertificate** | **string** | The text of the intermediate certificate chains. | [optional] [default to null]
 **IssuedBy** | **string** | The party that issued the certificate. | [optional] [default to null]
 **IssuedTo** | **string** | The party to whom the certificate is issued. | [optional] [default to null]
+**Key** | **string** | The text of private key. | [optional] [default to null]
 **KeySize** | **int32** | The size of the private key for the certificate in bits. Default is 2048 bits. | [optional] [default to null]
 **Locality** | **string** | The locality field listed in the certificate. | [optional] [default to null]
 **Organization** | **string** | The organization field listed in the certificate. | [optional] [default to null]

--- a/client/model_certificate.go
+++ b/client/model_certificate.go
@@ -25,6 +25,8 @@ type Certificate struct {
 	IssuedBy string `json:"issued_by,omitempty"`
 	// The party to whom the certificate is issued.
 	IssuedTo string `json:"issued_to,omitempty"`
+	// The text of private key.
+	Key string `json:"key,omitempty"`
 	// The size of the private key for the certificate in bits. Default is 2048 bits.
 	KeySize int32 `json:"key_size,omitempty"`
 	// The locality field listed in the certificate.


### PR DESCRIPTION
Adds missing 'key' property of certificate object. The key propery is used to export private key to Pure.