### PR TITLE
Fix Admin Role type

### DIFF
--- a/client/model_admin.go
+++ b/client/model_admin.go
@@ -22,5 +22,5 @@ type Admin struct {
 	Password string `json:"password,omitempty"`
 	// Public key for SSH access.
 	PublicKey string `json:"public_key,omitempty"`
-	Role string `json:"role,omitempty"`
+	Role AllOf28AdminsBodyRole `json:"role,omitempty"`
 }


### PR DESCRIPTION
The member Role in the Admin structure is defined as "string" and hence, the value is never populated. Corrected the type of the Role to AllOf28AdminsBodyRole.